### PR TITLE
Add port of gotham for st

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ See [shell/README.md](shell/README.md) for more information.
 
 Gotham color scheme for Jupyter notebook is available with installation instructions in [gotham-jupyter][jupyter-theme] repository.
 
+### st
+
+Go to your local repository of the [st][st], merge your own `config.h` with the
+values in `st/config.h`. Run `make` and `[sudo] make install`.
+
 ## Contributing
 
 I'm more than happy to accept Pull Requests of any kind: bug fixes, support for
@@ -211,3 +216,4 @@ MIT &copy; 2014-2015 Andrea Leopardi, see [the license][license-file].
 [emacs-version]: https://github.com/wasamasa/gotham-theme
 [chrome-theme]: https://chrome.google.com/webstore/detail/gotham/gnlfcflpgndokoemddgnhampfeaahmhc?authuser=1
 [jupyter-theme]: https://github.com/lepisma/gotham-jupyter
+[st]: http://st.suckless.org/

--- a/st/config.h
+++ b/st/config.h
@@ -1,0 +1,23 @@
+static const char *colorname[] = {
+  "#0a0f14",
+  "#c33027",
+  "#26a98b",
+  "#edb54b",
+  "#195465",
+  "#4e5165",
+  "#33859d",
+  "#98d1ce",
+  "#10151b",
+  "#d26939",
+  "#081f2d",
+  "#245361",
+  "#093748",
+  "#888ba5",
+  "#599caa",
+  "#d3ebe9",
+  [255] = 0
+};
+
+static unsigned int defaultfg = 7;
+static unsigned int defaultbg = 0;
+static unsigned int defaultcs = 7;


### PR DESCRIPTION
Hi! Thanks for creating gotham. I've created a port of the colorscheme for `st` (simple term).

`st` is configured with a header file, this is part of the file having to do with color configuration. Users wanting to make use of this need to copy these contents over to their copy and recompile.

More information about st: http://st.suckless.org/