### PR TITLE
Add Visual Studio Code version

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ Gotham color scheme for Jupyter notebook is available with installation instruct
 Go to your local repository of the [st][st], merge your own `config.h` with the
 values in `st/config.h`. Run `make` and `[sudo] make install`.
 
+### Visual Studio Code
+
+Gotham theme is now available on the [VSCode Marketplace](vscode-theme-marketplace).
+You can find more information in [vscode-theme-gotham][vscode-theme-repo] repository.
+
 ## Contributing
 
 I'm more than happy to accept Pull Requests of any kind: bug fixes, support for
@@ -217,3 +222,5 @@ MIT &copy; 2014-2015 Andrea Leopardi, see [the license][license-file].
 [chrome-theme]: https://chrome.google.com/webstore/detail/gotham/gnlfcflpgndokoemddgnhampfeaahmhc?authuser=1
 [jupyter-theme]: https://github.com/lepisma/gotham-jupyter
 [st]: http://st.suckless.org/
+[vscode-theme-marketplace]: https://marketplace.visualstudio.com/items?itemName=alireza94.theme-gotham
+[vscode-theme-repo]: https://github.com/alireza-ahmadi/vscode-theme-gotham

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ values in `st/config.h`. Run `make` and `[sudo] make install`.
 ### Visual Studio Code
 
 Gotham theme is now available on the [VSCode Marketplace](vscode-theme-marketplace).
-You can find more information in [vscode-theme-gotham][vscode-theme-repo] repository.
+You can find more information in the [vscode-theme-gotham][vscode-theme-repo] repository.
 
 ## Contributing
 


### PR DESCRIPTION
Hi, I have recently ported Gotham to Visual Studio Code. Please review the pull request and let me know if any change needed to be made. You can take a look at ported version on [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=alireza94.theme-gotham).

Just a quick note, Current version is ported from [Sublime version](https://github.com/whatyouhide/gotham-contrib/blob/master/sublime-text/) and while it's fine it has few differences with the original [vim-gotham](https://github.com/whatyouhide/vim-gotham). In the near future, I will add another theme into extension with the original version's color scheme.