### PR TITLE
Fix a typo in VSCode version description

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ values in `st/config.h`. Run `make` and `[sudo] make install`.
 
 ### Visual Studio Code
 
-Gotham theme is now available on the [VSCode Marketplace](vscode-theme-marketplace).
+Gotham theme is now available on the [VSCode Marketplace][vscode-theme-marketplace].
 You can find more information in the [vscode-theme-gotham][vscode-theme-repo] repository.
 
 ## Contributing


### PR DESCRIPTION
Sorry for another pull request, I have just noticed that I used `()` instead of `[]` in Marketplace link so the current link doesn't work, you can fix it yourself or merge my pull request.