### PR TITLE
Added Atom and Spyder syntax themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ values in `st/config.h`. Run `make` and `[sudo] make install`.
 Gotham theme is now available on the [VSCode Marketplace][vscode-theme-marketplace].
 You can find more information in the [vscode-theme-gotham][vscode-theme-repo] repository.
 
+### Atom
+
+A Gotham-inspired syntax theme, with special features, is available for Atom: [atom-ubik-syntax](atom-ubik-syntax).
+__Installation__:`apm install ubik-syntax`
+
+### Spyder
+
+A Gotham-inspired syntax theme is available for Spyder: [spyder-ubik-syntax](spyder-ubik-syntax)
+
 ## Contributing
 
 I'm more than happy to accept Pull Requests of any kind: bug fixes, support for
@@ -224,3 +233,5 @@ MIT &copy; 2014-2015 Andrea Leopardi, see [the license][license-file].
 [st]: http://st.suckless.org/
 [vscode-theme-marketplace]: https://marketplace.visualstudio.com/items?itemName=alireza94.theme-gotham
 [vscode-theme-repo]: https://github.com/alireza-ahmadi/vscode-theme-gotham
+[atom-ubik-syntax]: https://github.com/mr-ubik/atom-ubik-syntax
+[spyder-ubik-syntax]: https://github.com/mr-ubik/spyder-ubik-syntax

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ You can find more information in the [vscode-theme-gotham][vscode-theme-repo] re
 ### Atom
 
 A Gotham-inspired syntax theme, with special features, is available for Atom: [atom-ubik-syntax](atom-ubik-syntax).
-__Installation__:`apm install ubik-syntax`
+
+**Installation:** `apm install ubik-syntax`
 
 ### Spyder
 


### PR DESCRIPTION
### SPyder
![screenshot](https://cloud.githubusercontent.com/assets/16547060/21575516/5fd39c24-cf0e-11e6-8404-57484859c6d8.png)

### Atom
![screenshot](https://cloud.githubusercontent.com/assets/16547060/21575517/7c79709c-cf0e-11e6-841d-fc70d495d2ee.png)

I created two syntax themes, one for Atom and one for Spyder, I simply referred them in the README.md