### PR TITLE
Alacritty support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ or `$XDG_CONFIG_HOME/terminator/config` if you're running OS X.
 
 Restart terminator to load the Gotham colorscheme.
 
+### Alacritty
+
+Copy the contents of [alacritty/gotham.yml](alacritty/gotham.yml) into your
+`$XDG_CONFIG_HOME/alacritty.yml` or `$HOME/.alacritty.yml` after any
+pre-existing `colors:` mapping. After saving, it should change automatically.
+
+For more information, see the [Alacritty README][alacritty-configuration].
+
 ### PhpStorm/PyCharm
 
 Download [intellij/Gotham.icls](intellij/Gotham.icls) and then follow the
@@ -236,3 +244,4 @@ MIT &copy; 2014-2015 Andrea Leopardi, see [the license][license-file].
 [vscode-theme-repo]: https://github.com/alireza-ahmadi/vscode-theme-gotham
 [atom-ubik-syntax]: https://github.com/mr-ubik/atom-ubik-syntax
 [spyder-ubik-syntax]: https://github.com/mr-ubik/spyder-ubik-syntax
+[alacritty-configuration]: https://github.com/jwilm/alacritty#configuration

--- a/alacritty/gotham.yml
+++ b/alacritty/gotham.yml
@@ -1,0 +1,28 @@
+# Colors (Gotham)
+colors:
+  # Default colors
+  primary:
+    background: '0x0a0f14'
+    foreground: '0x98d1ce'
+
+  # Normal colors
+  normal:
+    black: '0x0a0f14'
+    red: '0xc33027'
+    green: '0x26a98b'
+    yellow: '0xedb54b'
+    blue: '0x195465'
+    magenta: '0x4e5165'
+    cyan: '0x33859d'
+    white: '0x98d1ce'
+
+  # Bright colors
+  bright:
+    black: '0x10151b'
+    red: '0xd26939'
+    green: '0x081f2d'
+    yellow: '0x245361'
+    blue: '0x093748'
+    magenta: '0x888ba5'
+    cyan: '0x599caa'
+    white: '0xd3ebe9'


### PR DESCRIPTION
[Alacritty](https://github.com/jwilm/alacritty) is a fairly new terminal emulator that uses YAML for its config. It's fairly straightforward as I mentioned in the first commit as I just took [the default](https://github.com/jwilm/alacritty/blob/56773fe7e7cdc999a6731934286858e763f96fda/alacritty.yml#L46) and changed the hex values.

Here's the output of `colortest-16`
![pic](https://cloud.githubusercontent.com/assets/22968784/21748601/878ff960-d54e-11e6-8b08-78ab30bb8e91.png)

Please let me know if there is anything else I should do.