### PR TITLE
Add os-independent schema loading instruction for Jetbrains IDEs (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,28 @@ pre-existing `colors:` mapping. After saving, it should change automatically.
 
 For more information, see the [Alacritty README][alacritty-configuration].
 
-### PhpStorm/PyCharm
+### Jetbrains IDEs (IntelliJ/Pycharm/WebStorm/PhpStorm/Rider/Clion/Rubymine//Goland)
 
 Download [intellij/Gotham.icls](intellij/Gotham.icls) and then follow the
 instructions for your OS.
+
+Open IDE then navigate to: 
+
+(Windows & Linux) `"File > Settings > Editor > Colors Scheme"` 
+
+(OSX) `"PyCharm > Preferences > Editor > Color Scheme"`
+
+Open dropdown by clicking `⚙▾` button which should be next to scheme 
+selection window `(Scheme: [...] ⚙▾)`.
+
+Choose `Import Scheme`.
+
+Find and load downloaded `Gotham.icls` file.
+
+Colorscheme should change immediately and `Gotham` should appear on list of available schemas.  
+(In case of external schemas, `⚙▾` dropdown contains `delete` option for schema removal)
+
+### Jetbrains IDEs - manual installation:
 
 ##### OSX
 


### PR DESCRIPTION
* I removed redundant os-specific sections but I'm not sure about OSX, I tested it only on Linux/Windows. I'm not 100% sure if that's good so I can revert it on request. Maybe it's better to keep it as some kind of "B plan".

* I changed section name to group all  products but listed them in case of someone who will search for specific Jetbrains IDE.

* I added little hint about schema removal as it seemed to me useful information.