### PR TITLE
Fixed colours for Windows Terminal

### DIFF
--- a/windows-terminal/settings.json
+++ b/windows-terminal/settings.json
@@ -3,7 +3,7 @@
         {
             "name": "Gotham",
             "background": "#0a0f14",
-            "foreground": "#cccccc",
+            "foreground": "#98d1ce",
             "cursorColor": "#98d1ce",
             "black": "#505050",
             "blue": "#13789c",
@@ -21,7 +21,7 @@
             "red": "#dc362c",
             "white": "#98d1ce",
             "yellow": "#edb54b",
-            "selectionBackground": "#ffffff"
+            "selectionBackground": "#0c3040"
           }
     ]
 }


### PR DESCRIPTION
cursorColor and selectionBackground were set to incorrect values, adjusted to match Visual Studio Code colours